### PR TITLE
Version change fixes  and other fixes

### DIFF
--- a/notebooks/9-convolutional-neural-networks.ipynb
+++ b/notebooks/9-convolutional-neural-networks.ipynb
@@ -735,8 +735,8 @@
     "X_test_conv = 2*(X_test_conv/255 - 0.5)\n",
     "\n",
     "# convert string classes to integer equivalents\n",
-    "y_train = y_train.astype(np.int)\n",
-    "y_test  = y_test.astype(np.int)\n",
+    "y_train = y_train.astype(np.int32)\n",
+    "y_test  = y_test.astype(np.int32)\n",
     "\n",
     "# also add dimension to target\n",
     "y_train_conv = y_train.reshape(-1,1)\n",
@@ -903,7 +903,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "score = model_conv.evaluate(X_test_conv, y_test)\n",
+    "score = model_conv.evaluate(X_test_conv, y_test_conv)\n",
     "print('Test score:', score[0])\n",
     "print('Test accuracy:', score[1])"
    ]
@@ -1466,16 +1466,16 @@
    ]
   }
  ],
- "nbformat": 4,
- "nbformat_minor": 0,
  "metadata": {
   "accelerator": "GPU",
   "colab": {
    "toc_visible": true
   },
   "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3"
+   "display_name": "Python 3",
+   "name": "python3"
   }
- }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/notebooks/9-convolutional-neural-networks.md
+++ b/notebooks/9-convolutional-neural-networks.md
@@ -591,8 +591,8 @@ X_train_conv = 2*(X_train_conv/255 - 0.5)
 X_test_conv = 2*(X_test_conv/255 - 0.5)
 
 # convert string classes to integer equivalents
-y_train = y_train.astype(np.int)
-y_test  = y_test.astype(np.int)
+y_train = y_train.astype(np.int32)
+y_test  = y_test.astype(np.int32)
 
 # also add dimension to target
 y_train_conv = y_train.reshape(-1,1)
@@ -733,7 +733,7 @@ y_pred_conv = np.argmax(y_pred_prob_conv, axis=-1)
 
 ::: {.cell .code }
 ```python
-score = model_conv.evaluate(X_test_conv, y_test)
+score = model_conv.evaluate(X_test_conv, y_test_conv)
 print('Test score:', score[0])
 print('Test accuracy:', score[1])
 ```

--- a/notebooks/9-fine-tune-rock-paper-scissors.ipynb
+++ b/notebooks/9-fine-tune-rock-paper-scissors.ipynb
@@ -4,8 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Demo: Transfer learning\n",
-    "=======================\n",
+    "# Demo: Transfer learning\n",
     "\n",
     "*Fraida Fund*"
    ]
@@ -28,8 +27,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Import dependencies\n",
-    "-------------------"
+    "## Import dependencies"
    ]
   },
   {
@@ -49,16 +47,14 @@
     "import random\n",
     "\n",
     "print('Python version:', platform.python_version())\n",
-    "print('Tensorflow version:', tf.__version__)\n",
-    "print('Keras version:', tf.keras.__version__)"
+    "print('Tensorflow version:', tf.__version__)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Import data\n",
-    "-----------"
+    "## Import data"
    ]
   },
   {
@@ -97,7 +93,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = tfds.show_examples(ds_info, ds_train)"
+    "fig = tfds.show_examples(ds_train, ds_info)"
    ]
   },
   {
@@ -113,8 +109,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Pre-process dataset\n",
-    "-------------------"
+    "## Pre-process dataset"
    ]
   },
   {
@@ -172,8 +167,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "train_numpy = np.vstack(tfds.as_numpy(ds_train))\n",
-    "test_numpy = np.vstack(tfds.as_numpy(ds_test))\n",
+    "train_numpy = np.vstack(list(tfds.as_numpy(ds_train)))\n",
+    "test_numpy = np.vstack(list(tfds.as_numpy(ds_test)))\n",
     "\n",
     "X_train = np.array(list(map(lambda x: x[0]['image'], train_numpy)))\n",
     "y_train = np.array(list(map(lambda x: x[0]['label'], train_numpy)))\n",
@@ -186,8 +181,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Upload custom test sample\n",
-    "-------------------------\n",
+    "## Upload custom test sample\n",
     "\n",
     "This code expects a PNG image."
    ]
@@ -241,8 +235,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Classify with MobileNetV2\n",
-    "-------------------------"
+    "## Classify with MobileNetV2"
    ]
   },
   {
@@ -594,8 +587,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Background: fine-tuning a model\n",
-    "-------------------------------"
+    "## Background: fine-tuning a model"
    ]
   },
   {
@@ -609,7 +601,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![Image via [PlotNeuralNet](https://github.com/HarisIqbal88/PlotNeuralNet)](https://raw.githubusercontent.com/LongerVision/Resource/master/AI/Visualization/PlotNeuralNet/vgg16.png)"
+    "<figure>\n",
+    "<img src=\"https://raw.githubusercontent.com/LongerVision/Resource/master/AI/Visualization/PlotNeuralNet/vgg16.png\" alt=\"Image via PlotNeuralNet\" />\n",
+    "<figcaption aria-hidden=\"true\">Image via <a href=\"https://github.com/HarisIqbal88/PlotNeuralNet\">PlotNeuralNet</a></figcaption>\n",
+    "</figure>"
    ]
   },
   {
@@ -653,8 +648,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Train our own classification head\n",
-    "---------------------------------"
+    "## Train our own classification head"
    ]
   },
   {
@@ -859,8 +853,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Fine-tune model\n",
-    "---------------"
+    "## Fine-tune model"
    ]
   },
   {
@@ -977,8 +970,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Classify custom test sample\n",
-    "---------------------------"
+    "## Classify custom test sample"
    ]
   },
   {
@@ -1010,8 +1002,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Some comments\n",
-    "-------------"
+    "## Some comments"
    ]
   },
   {
@@ -1044,16 +1035,16 @@
    ]
   }
  ],
- "nbformat": 4,
- "nbformat_minor": 0,
  "metadata": {
-  "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3"
-  },
   "accelerator": "GPU",
   "colab": {
-   "toc_visible": "true"
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
   }
- }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/notebooks/9-fine-tune-rock-paper-scissors.md
+++ b/notebooks/9-fine-tune-rock-paper-scissors.md
@@ -48,7 +48,6 @@ import random
 
 print('Python version:', platform.python_version())
 print('Tensorflow version:', tf.__version__)
-print('Keras version:', tf.keras.__version__)
 ```
 :::
 
@@ -81,7 +80,7 @@ import tensorflow_datasets as tfds
 
 ::: {.cell .code }
 ```python
-fig = tfds.show_examples(ds_info, ds_train)
+fig = tfds.show_examples(ds_train, ds_info)
 ```
 :::
 
@@ -131,8 +130,8 @@ We'l convert to `numpy` format again:
 
 ::: {.cell .code }
 ```python
-train_numpy = np.vstack(tfds.as_numpy(ds_train))
-test_numpy = np.vstack(tfds.as_numpy(ds_test))
+train_numpy = np.vstack(list(tfds.as_numpy(ds_train)))
+test_numpy = np.vstack(list(tfds.as_numpy(ds_test)))
 
 X_train = np.array(list(map(lambda x: x[0]['image'], train_numpy)))
 y_train = np.array(list(map(lambda x: x[0]['label'], train_numpy)))


### PR DESCRIPTION
## Fixes for 9-fine-tune-rock-paper-scissors Notebook

1. **Keras Version Print Removal**
   - **Issue**: No attribute `__version__` directly accessible under `tf.keras`.
   - **Fix**: Removed the line `print('Keras version:', tf.keras.__version__)`.

2. **Incorrect Parameter Order in `tfds.show_examples`**
   - **Issue**: The parameter order was reversed.
   - **Fix**: Changed from `fig = tfds.show_examples(ds_info, ds_train)` to `fig = tfds.show_examples(ds_train, ds_info)`.

3. **`np.vstack` Requires a Sequence Input**
   - **Issue**: `tfds.as_numpy` returns iterators, but `np.vstack` requires a sequence.
   - **Fix**: Changed from:
     ```python
     train_numpy = np.vstack(tfds.as_numpy(ds_train))
     test_numpy  = np.vstack(tfds.as_numpy(ds_test))
     ```
     to:
     ```python
     train_numpy = np.vstack(list(tfds.as_numpy(ds_train)))
     test_numpy = np.vstack(list(tfds.as_numpy(ds_test)))
     ```

## Fixes for CNN Notebook

1. **Data Type Specification for numpy Arrays**
   - **Issue**: numpy has no attribute `int`.
   - **Fix**: Changed from `y_train = y_train.astype(np.int)` and `y_test = y_test.astype(np.int)` to `y_train = y_train.astype(np.int32)` and `y_test = y_test.astype(np.int32)`.

2. **Type Error in Model Evaluation**
   - **Issue**: TypeError encountered suggesting a dimensional or type mismatch.
   - **Fix**: Changed from `score = model_conv.evaluate(X_test_conv, y_test)` to `score = model_conv.evaluate(X_test_conv, y_test_conv)`.
